### PR TITLE
Inject backend service's host and port via env. variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,3 @@ In another terminal, run the UI:
 ```
 
 The UI will be served on port 9000. navigate to http://localhost:9000 to view it. The UI client files can be found in `moodykubie-ui/static`
-


### PR DESCRIPTION
This is useful when trying to link Docker containers, or when deploying them as Kubernetes services, so they can talk to each others.

Example:
```
$ docker run -p 8989:8989 --name moodykubie-service weaveworks/moodykubie-service:latest
$ docker run -p 9000:9000 --link moodykubie-service \
        -e SERVICE_HOST=moodykubie-service \
        -e SERVICE_PORT=8989 \
        weaveworks/moodykubie-ui:latest
```