### PR TITLE
Expose Prometheus counter for emotions

### DIFF
--- a/moodykubie-service/.dockerignore
+++ b/moodykubie-service/.dockerignore
@@ -1,2 +1,3 @@
 app/node_modules/**/*
 app/node_modules
+app/package-lock.json

--- a/moodykubie-service/.gitignore
+++ b/moodykubie-service/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+app/package-lock.json

--- a/moodykubie-service/app/index.js
+++ b/moodykubie-service/app/index.js
@@ -2,6 +2,13 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const emotions = require("./emotions");
 
+const prom = require('prom-client');
+const counter = new prom.Counter({
+  name: 'emotions_total',
+  help: 'Total number of recognised emotions.',
+  labelNames: ['emotion']
+});
+
 const app = express();
 app.use(bodyParser.raw({
     inflate: true,
@@ -27,6 +34,7 @@ app.post('/classify-emotions', function (req, res) {
         var classifier = emotions.configuredClassifier();
         emotions.getEmotions(tracker, classifier, req.body, once(function (reply) {
             console.log("Image Classified after " + reply.iterations + " iterations");
+            counter.labels(reply.emotion).inc();
             res.json(reply);
         }));
     } catch (e) {
@@ -37,6 +45,11 @@ app.post('/classify-emotions', function (req, res) {
 
 console.log("Emotion detection service live on port 8989");
 const server = app.listen(8989);
+
+app.get('/metrics', (req, res) => {
+  res.set('Content-Type', prom.register.contentType);
+  res.end(prom.register.metrics());
+});
 
 process.on('uncaughtException', function(err) {
     console.error(err);

--- a/moodykubie-service/app/index.js
+++ b/moodykubie-service/app/index.js
@@ -36,8 +36,18 @@ app.post('/classify-emotions', function (req, res) {
 });
 
 console.log("Emotion detection service live on port 8989");
-app.listen(8989);
+const server = app.listen(8989);
 
 process.on('uncaughtException', function(err) {
     console.error(err);
+});
+
+process.on('SIGINT', () => {
+  server.close((err) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    process.exit(0);
+  });
 });

--- a/moodykubie-service/app/index.js
+++ b/moodykubie-service/app/index.js
@@ -1,24 +1,18 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const emotions = require("./emotions");
 
-
-var express = require('express')
-var bodyParser = require('body-parser');
-
-var emotions = require("./emotions");
-
-
-
-
-var app = express()
+const app = express();
 app.use(bodyParser.raw({
     inflate: true,
     limit: '100kb',
     type: 'application/octet-stream'
 }));
 
-function once(fn, context){
+function once(fn, context) {
     var execd = false;
-    return function(){
-        if (!execd){
+    return function() {
+        if (!execd) {
             execd = true;
             return fn.apply(context || this, arguments);
         }
@@ -26,26 +20,24 @@ function once(fn, context){
 }
 
 app.post('/classify-emotions', function (req, res) {
-
-    console.log("Classifying image")
+    console.log("Classifying image");
     var canvas = null;
     try{
         var tracker = emotions.configuredTracker();
         var classifier = emotions.configuredClassifier();
-        emotions.getEmotions(tracker, classifier, req.body, once(function (reply){
-            console.log("Image Classified after " + reply.iterations + " iterations")
-            res.json(reply)
+        emotions.getEmotions(tracker, classifier, req.body, once(function (reply) {
+            console.log("Image Classified after " + reply.iterations + " iterations");
+            res.json(reply);
         }));
-    }catch (e){
+    } catch (e) {
         console.error(e);
-        res.status(500).json({error: "Failed to process image."})
+        res.status(500).json({error: "Failed to process image."});
     }
-})
+});
 
-console.log("Emotion detection service live on port 8989")
-app.listen(8989)
+console.log("Emotion detection service live on port 8989");
+app.listen(8989);
 
-process.on('uncaughtException', function(err){
-    console.error(err)
-})
-
+process.on('uncaughtException', function(err) {
+    console.error(err);
+});

--- a/moodykubie-service/app/package.json
+++ b/moodykubie-service/app/package.json
@@ -14,6 +14,7 @@
     "express": "^4.16.2",
     "jsfeat": "0.0.8",
     "numeric": "^1.2.6",
+    "prom-client": "^10.2.2",
     "window-shim": "^1.0.0"
   }
 }


### PR DESCRIPTION
Changelog:

- Expose Prometheus counter for emotions
- Handle `SIGINT` to gracefully shutdown and be more friendly with Docker and Kubernetes
- Clean-up

Example:
```
$ docker run --rm --name moodykubie-service -p 8989:8989 weaveworks/moodykubie-service:latest
$ docker run --link moodykubie-service \
        -e SERVICE_HOST=moodykubie-service \
        -e SERVICE_PORT=8989 \
        -p 9000:9000 weaveworks/moodykubie-ui:latest
### Trigger a face recognition from web browser...
$ curl localhost:8989/metrics
# HELP emotions_total Total number of recognised emotions.
# TYPE emotions_total counter
emotions_total{emotion="anger"} 1
```
