### PR TITLE
Add Kubernetes manifests and related instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ curl localhost:8989/metrics
 emotions_total{emotion="anger"} 1
 ```
 
+### Kubernetes
+
+```bash
+cd /path/to/this/project
+kubectl apply -f kubernetes
+```
+
 ## Build & Push
 
 Get hold of an ARM 32 bit machine (Cubieboard, RPi, etc.) or start a C1 instance on Scaleway, and run the below:

--- a/kubernetes/moodykubie-service-dep.yaml
+++ b/kubernetes/moodykubie-service-dep.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: moodykubie-service
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: moodykubie-service
+    spec:
+      containers:
+      - name: moodykubie-service
+        image: weaveworks/moodykubie-service:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8989
+          name: http

--- a/kubernetes/moodykubie-service-svc.yaml
+++ b/kubernetes/moodykubie-service-svc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: moodykubie-service
+spec:
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8989
+  selector:
+    name: moodykubie-service

--- a/kubernetes/moodykubie-ui-dep.yaml
+++ b/kubernetes/moodykubie-ui-dep.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: moodykubie-ui
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: moodykubie-ui
+    spec:
+      containers:
+      - name: moodykubie-ui
+        image: weaveworks/moodykubie-ui:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9000
+          name: http
+        env:
+        - name: SERVICE_HOST
+          value: "$(MOODYKUBIE_SERVICE_SERVICE_HOST)"
+        - name: SERVICE_PORT
+          value: "$(MOODYKUBIE_SERVICE_SERVICE_PORT)"

--- a/kubernetes/moodykubie-ui-svc.yaml
+++ b/kubernetes/moodykubie-ui-svc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: moodykubie-ui
+spec:
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9000
+  selector:
+    name: moodykubie-ui


### PR DESCRIPTION
Couldn't fully test this under `minikube` given the images are for ARM and I got:
```
standard_init_linux.go:187: exec user process caused "exec format error"
```
as a result.
However, by swapping these with some Nginx containers, I was able to confirm

- `-ui`'s environment variables are properly set to `-service`'s hosts/ports
- `-ui` can successfully talk to `-service`
- both services should be available to outside the cluster, which may be useful for demos.